### PR TITLE
Ensure K3S service is enabled after running the role

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,7 +14,6 @@
   ansible.builtin.systemd:
     name: "{{ k3s_service }}"
     state: restarted
-    enabled: true
 
 - name: Reload systemd
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -171,6 +171,12 @@
     mode: "0755"
     content: "{{ item.content }}"
 
+- name: Start and enable K3S
+  ansible.builtin.systemd:
+    name: "{{ k3s_service }}"
+    state: started
+    enabled: true
+
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
 


### PR DESCRIPTION
It is not given that handlers are run under every circumstance. Define as a task the state we want the K3S service to be in.